### PR TITLE
Only run linting steps on Linux.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,14 +33,17 @@ jobs:
 
       - name: Ensure code is formatted with gofmt
         run: make check-fmt
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Ensure generated code was recreated if needed
         run: make check-generate
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Lint with golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           only-new-issues: true
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Run unit tests
         run: make test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -47,7 +47,10 @@ install-golangci-lint:
 lint: install-golangci-lint
 	@golangci-lint run ./...
 
-check-fmt:
+fmt:
+	@go fmt ./...
+
+check-fmt: fmt
 	echo "==> Checking that code complies with go fmt requirements..."
 	git diff --exit-code; if [ $$? -eq 1 ]; then \
 		echo "Found files that are not fmt'ed."; \


### PR DESCRIPTION
Some small CI fixups. Due to some false positives from goimports on Windows, this makes it so that it only runs on Ubuntu. There's not much value in linting on multiple platforms. Actual unit tests are still run everywhere.

See: https://github.com/golangci/golangci-lint/issues/635 & https://github.com/golangci/golangci-lint/issues/580

https://github.com/digitalocean/packer-plugin-digitalocean/runs/7437869229?check_suite_focus=true#step:7:28