### PR TITLE
docs: point to digitalocean provider in generated docs

### DIFF
--- a/docs/builders/digitalocean.mdx
+++ b/docs/builders/digitalocean.mdx
@@ -39,8 +39,8 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     digitalocean = {
-      version = ">= 1.0.0"
-      source  = "github.com/hashicorp/digitalocean"
+      version = ">= 1.0.4"
+      source  = "github.com/digitalocean/digitalocean"
     }
   }
 }

--- a/docs/post-processors/digitalocean-import.mdx
+++ b/docs/post-processors/digitalocean-import.mdx
@@ -37,8 +37,8 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     digitalocean = {
-      version = ">= 1.0.0"
-      source  = "github.com/hashicorp/digitalocean"
+      version = ">= 1.0.4"
+      source  = "github.com/digitalocean/digitalocean"
     }
   }
 }


### PR DESCRIPTION
I was leveraging this plugin, and noticed that the README has been updated to point to DigitalOcean now owning this provider, but the docs for the builder and post-processor still point to HashiCorp. Updated those docs to match the HCL on the README.

Notably, these docs are what show up on Packer's site: https://www.packer.io/plugins/builders/digitalocean