### PR TITLE
Check in docs-partials for new data source.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ main
 dist/*
 packer-plugin-digitalocean
 .vscode/
-docs-partials/
 docs.zip

--- a/docs-partials/datasource/image/Config-not-required.mdx
+++ b/docs-partials/datasource/image/Config-not-required.mdx
@@ -1,0 +1,19 @@
+<!-- Code generated from the comments of the Config struct in datasource/image/data.go; DO NOT EDIT MANUALLY -->
+
+- `api_url` (string) - A non-standard API endpoint URL. Set this if you are  using a DigitalOcean API
+  compatible service. It can also be specified via environment variable DIGITALOCEAN_API_URL.
+
+- `name` (string) - The name of the image to return. Only one of `name` or `name_regex` may be provided.
+
+- `name_regex` (string) - A regex matching the name of the image to return. Only one of `name` or `name_regex` may be provided.
+
+- `type` (string) - Filter the images searched by type. This may be one of `application`, `distribution`, or `user`.
+  By default, all image types are searched.
+
+- `region` (string) - A DigitalOcean region slug (e.g. `nyc3`). When provided, only images available in that region
+  will be returned.
+
+- `latest` (bool) - A boolean value determining how to handle multiple matching images. By default, multiple matching images
+  results in an error. When set to `true`, the most recently created image is returned instead.
+
+<!-- End of code generated from the comments of the Config struct in datasource/image/data.go; -->

--- a/docs-partials/datasource/image/Config-required.mdx
+++ b/docs-partials/datasource/image/Config-required.mdx
@@ -1,0 +1,6 @@
+<!-- Code generated from the comments of the Config struct in datasource/image/data.go; DO NOT EDIT MANUALLY -->
+
+- `api_token` (string) - The API token to used to access your account. It can also be specified via
+  the DIGITALOCEAN_TOKEN or DIGITALOCEAN_ACCESS_TOKEN environment variables.
+
+<!-- End of code generated from the comments of the Config struct in datasource/image/data.go; -->

--- a/docs-partials/datasource/image/DatasourceOutput.mdx
+++ b/docs-partials/datasource/image/DatasourceOutput.mdx
@@ -1,0 +1,7 @@
+<!-- Code generated from the comments of the DatasourceOutput struct in datasource/image/data.go; DO NOT EDIT MANUALLY -->
+
+- `image_id` (int) - The ID of the found image.
+
+- `image_regions` ([]string) - The regions the found image is availble in.
+
+<!-- End of code generated from the comments of the DatasourceOutput struct in datasource/image/data.go; -->


### PR DESCRIPTION
Looks like I managed to break the release process by not checking in the  docs-partials for the new data source. I assumed that since they are generated, it was not desired but looks like it is expected as the builder docs-partials are as well.

```
2022/09/07 20:20:30 Copying "docs" to "docs/"
2022/09/07 20:20:30 Replacing @include '...' calls in docs/
2022/09/07 20:20:30 renderDocsFile: open docs-partials/datasource/image/Config-required.mdx: no such file or directory
```

https://github.com/digitalocean/packer-plugin-digitalocean/runs/8236600596?check_suite_focus=true#step:7:50