### PR TITLE
dependabot: ignore go-cty updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "github.com/hashicorp/packer-plugin-sdk"
-      - dependency-name: "github.com/hashicorp/hcl/v2"
-      - dependency-name: "github.com/zclconf/go-cty"
+      - dependency-name: "github.com/digitalocean/godo"
+      # Currently pinned due to a breaking change.
+      # See: https://github.com/digitalocean/packer-plugin-digitalocean/pull/89#issuecomment-1503016605
+      # - dependency-name: "github.com/hashicorp/hcl/v2"
+      # - dependency-name: "github.com/zclconf/go-cty"
 


### PR DESCRIPTION
Following the recommendation of the Packer team, this is pinning the versions of `github.com/hashicorp/hcl/v2` and `github.com/zclconf/go-cty` by telling dependabot updates for them.

```
In v1.11.0 of github.com/zclconf/go-cty, encoding/gob support was removed from the package. The Packer plugin SDK relies on gob for supporting HCL2 templates. The removal of the encoding causes Packer to crash when using HCL2 templates.

The team and I are working internally to find the best path forward, as a change to the wire protocol from gob will introduce a breaking change and plugin incompatibilities. We are working to notify plugin developers of the incompatible go-cty package and ask that all external plugins pin the versions of the following two packages to those used by the Packer plugin SDK.

github.com/hashicorp/hcl/v2 v2.13.0
github.com/zclconf/go-cty v1.10.0
```
https://github.com/digitalocean/packer-plugin-digitalocean/pull/90#issuecomment-1503017337


I have added godo to the allow list as well since I was in here already.