### PR TITLE
Include SSHTemporaryKeyPair docs in builder docs.

### DIFF
--- a/docs/builders/digitalocean.mdx
+++ b/docs/builders/digitalocean.mdx
@@ -106,6 +106,8 @@ In addition to the builder options, a
 
 @include 'packer-plugin-sdk/communicator/Config-not-required.mdx'
 
+@include 'packer-plugin-sdk/communicator/SSHTemporaryKeyPair-not-required.mdx'
+
 @include 'packer-plugin-sdk/communicator/SSH-not-required.mdx'
 
 @include 'packer-plugin-sdk/communicator/SSH-Private-Key-File-not-required.mdx'


### PR DESCRIPTION
We are missing docs on the configuration options to the temporary SSH key pairs that are generated if you do not provide your own.

To validate, run `make ci-release-docs` and see that docs for `temporary_key_pair_type` and `temporary_key_pair_bits` have been injected.