### PR TITLE
Enable retrying failed godo requests

### DIFF
--- a/builder/digitalocean/builder.go
+++ b/builder/digitalocean/builder.go
@@ -57,6 +57,14 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 		opts = append(opts, godo.SetBaseURL(b.config.APIURL))
 	}
+	if *b.config.HTTPRetryMax > 0 {
+		opts = append(opts, godo.WithRetryAndBackoffs(godo.RetryConfig{
+			RetryMax:     *b.config.HTTPRetryMax,
+			RetryWaitMin: b.config.HTTPRetryWaitMin,
+			RetryWaitMax: b.config.HTTPRetryWaitMax,
+			Logger:       log.Default(),
+		}))
+	}
 
 	client, err := godo.New(oauth2.NewClient(context.TODO(), &APITokenSource{
 		AccessToken: b.config.APIToken,

--- a/builder/digitalocean/builder_acc_test.go
+++ b/builder/digitalocean/builder_acc_test.go
@@ -60,7 +60,12 @@ func makeTemplateWithImageId(t *testing.T) string {
 		}
 
 		ua := useragent.String(version.PluginVersion.FormattedVersion())
-		opts := []godo.ClientOpt{godo.SetUserAgent(ua)}
+		opts := []godo.ClientOpt{
+			godo.SetUserAgent(ua),
+			godo.WithRetryAndBackoffs(godo.RetryConfig{
+				RetryMax: 5,
+			}),
+		}
 		client, err := godo.New(oauth2.NewClient(context.TODO(), &APITokenSource{
 			AccessToken: token,
 		}), opts...)

--- a/builder/digitalocean/config.hcl2spec.go
+++ b/builder/digitalocean/config.hcl2spec.go
@@ -69,6 +69,9 @@ type FlatConfig struct {
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
 	APIToken                  *string           `mapstructure:"api_token" required:"true" cty:"api_token" hcl:"api_token"`
 	APIURL                    *string           `mapstructure:"api_url" required:"false" cty:"api_url" hcl:"api_url"`
+	HTTPRetryMax              *int              `mapstructure:"http_retry_max" required:"false" cty:"http_retry_max" hcl:"http_retry_max"`
+	HTTPRetryWaitMax          *float64          `mapstructure:"http_retry_wait_max" required:"false" cty:"http_retry_wait_max" hcl:"http_retry_wait_max"`
+	HTTPRetryWaitMin          *float64          `mapstructure:"http_retry_wait_min" required:"false" cty:"http_retry_wait_min" hcl:"http_retry_wait_min"`
 	Region                    *string           `mapstructure:"region" required:"true" cty:"region" hcl:"region"`
 	Size                      *string           `mapstructure:"size" required:"true" cty:"size" hcl:"size"`
 	Image                     *string           `mapstructure:"image" required:"true" cty:"image" hcl:"image"`
@@ -160,6 +163,9 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
 		"api_token":                    &hcldec.AttrSpec{Name: "api_token", Type: cty.String, Required: false},
 		"api_url":                      &hcldec.AttrSpec{Name: "api_url", Type: cty.String, Required: false},
+		"http_retry_max":               &hcldec.AttrSpec{Name: "http_retry_max", Type: cty.Number, Required: false},
+		"http_retry_wait_max":          &hcldec.AttrSpec{Name: "http_retry_wait_max", Type: cty.Number, Required: false},
+		"http_retry_wait_min":          &hcldec.AttrSpec{Name: "http_retry_wait_min", Type: cty.Number, Required: false},
 		"region":                       &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"size":                         &hcldec.AttrSpec{Name: "size", Type: cty.String, Required: false},
 		"image":                        &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},

--- a/datasource/image/data.hcl2spec.go
+++ b/datasource/image/data.hcl2spec.go
@@ -10,13 +10,16 @@ import (
 // FlatConfig is an auto-generated flat version of Config.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfig struct {
-	APIToken  *string `mapstructure:"api_token" required:"true" cty:"api_token" hcl:"api_token"`
-	APIURL    *string `mapstructure:"api_url" cty:"api_url" hcl:"api_url"`
-	Name      *string `mapstructure:"name" cty:"name" hcl:"name"`
-	NameRegex *string `mapstructure:"name_regex" cty:"name_regex" hcl:"name_regex"`
-	Type      *string `mapstructure:"type" cty:"type" hcl:"type"`
-	Region    *string `mapstructure:"region" cty:"region" hcl:"region"`
-	Latest    *bool   `mapstructure:"latest" cty:"latest" hcl:"latest"`
+	APIToken         *string  `mapstructure:"api_token" required:"true" cty:"api_token" hcl:"api_token"`
+	APIURL           *string  `mapstructure:"api_url" cty:"api_url" hcl:"api_url"`
+	HTTPRetryMax     *int     `mapstructure:"http_retry_max" required:"false" cty:"http_retry_max" hcl:"http_retry_max"`
+	HTTPRetryWaitMax *float64 `mapstructure:"http_retry_wait_max" required:"false" cty:"http_retry_wait_max" hcl:"http_retry_wait_max"`
+	HTTPRetryWaitMin *float64 `mapstructure:"http_retry_wait_min" required:"false" cty:"http_retry_wait_min" hcl:"http_retry_wait_min"`
+	Name             *string  `mapstructure:"name" cty:"name" hcl:"name"`
+	NameRegex        *string  `mapstructure:"name_regex" cty:"name_regex" hcl:"name_regex"`
+	Type             *string  `mapstructure:"type" cty:"type" hcl:"type"`
+	Region           *string  `mapstructure:"region" cty:"region" hcl:"region"`
+	Latest           *bool    `mapstructure:"latest" cty:"latest" hcl:"latest"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -31,13 +34,16 @@ func (*Config) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec }
 // The decoded values from this spec will then be applied to a FlatConfig.
 func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"api_token":  &hcldec.AttrSpec{Name: "api_token", Type: cty.String, Required: false},
-		"api_url":    &hcldec.AttrSpec{Name: "api_url", Type: cty.String, Required: false},
-		"name":       &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
-		"name_regex": &hcldec.AttrSpec{Name: "name_regex", Type: cty.String, Required: false},
-		"type":       &hcldec.AttrSpec{Name: "type", Type: cty.String, Required: false},
-		"region":     &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
-		"latest":     &hcldec.AttrSpec{Name: "latest", Type: cty.Bool, Required: false},
+		"api_token":           &hcldec.AttrSpec{Name: "api_token", Type: cty.String, Required: false},
+		"api_url":             &hcldec.AttrSpec{Name: "api_url", Type: cty.String, Required: false},
+		"http_retry_max":      &hcldec.AttrSpec{Name: "http_retry_max", Type: cty.Number, Required: false},
+		"http_retry_wait_max": &hcldec.AttrSpec{Name: "http_retry_wait_max", Type: cty.Number, Required: false},
+		"http_retry_wait_min": &hcldec.AttrSpec{Name: "http_retry_wait_min", Type: cty.Number, Required: false},
+		"name":                &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
+		"name_regex":          &hcldec.AttrSpec{Name: "name_regex", Type: cty.String, Required: false},
+		"type":                &hcldec.AttrSpec{Name: "type", Type: cty.String, Required: false},
+		"region":              &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
+		"latest":              &hcldec.AttrSpec{Name: "latest", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/docs-partials/builder/digitalocean/Config-not-required.mdx
+++ b/docs-partials/builder/digitalocean/Config-not-required.mdx
@@ -4,6 +4,13 @@
   using a DigitalOcean API compatible service. It can also be specified via
   environment variable DIGITALOCEAN_API_URL.
 
+- `http_retry_max` (\*int) - The maximum number of retries for requests that fail with a 429 or 500-level error.
+  The default value is 5. Set to 0 to disable reties.
+
+- `http_retry_wait_max` (\*float64) - The maximum wait time (in seconds) between failed API requests. Default: 30.0
+
+- `http_retry_wait_min` (\*float64) - The minimum wait time (in seconds) between failed API requests. Default: 1.0
+
 - `private_networking` (bool) - Set to true to enable private networking
   for the droplet being created. This defaults to false, or not enabled.
 

--- a/docs-partials/datasource/image/Config-not-required.mdx
+++ b/docs-partials/datasource/image/Config-not-required.mdx
@@ -3,6 +3,13 @@
 - `api_url` (string) - A non-standard API endpoint URL. Set this if you are  using a DigitalOcean API
   compatible service. It can also be specified via environment variable DIGITALOCEAN_API_URL.
 
+- `http_retry_max` (\*int) - The maximum number of retries for requests that fail with a 429 or 500-level error.
+  The default value is 5. Set to 0 to disable reties.
+
+- `http_retry_wait_max` (\*float64) - The maximum wait time (in seconds) between failed API requests. Default: 30.0
+
+- `http_retry_wait_min` (\*float64) - The minimum wait time (in seconds) between failed API requests. Default: 1.0
+
 - `name` (string) - The name of the image to return. Only one of `name` or `name_regex` may be provided.
 
 - `name_regex` (string) - A regex matching the name of the image to return. Only one of `name` or `name_regex` may be provided.

--- a/docs-partials/post-processor/digitalocean-import/Config-not-required.mdx
+++ b/docs-partials/post-processor/digitalocean-import/Config-not-required.mdx
@@ -1,0 +1,30 @@
+<!-- Code generated from the comments of the Config struct in post-processor/digitalocean-import/post-processor.go; DO NOT EDIT MANUALLY -->
+
+- `http_retry_max` (\*int) - The maximum number of retries for requests that fail with a 429 or 500-level error.
+  The default value is 5. Set to 0 to disable reties.
+
+- `http_retry_wait_max` (\*float64) - The maximum wait time (in seconds) between failed API requests. Default: 30.0
+
+- `http_retry_wait_min` (\*float64) - The minimum wait time (in seconds) between failed API requests. Default: 1.0
+
+- `space_object_name` (string) - The name of the key used in the Space where the image file will be copied
+  to for import. This is treated as a [template engine](/docs/templates/legacy_json_templates/engine).
+  Therefore, you may use user variables and template functions in this field.
+  If not specified, this will default to `packer-import-{{timestamp}}`.
+
+- `skip_clean` (bool) - Whether we should skip removing the image file uploaded to Spaces after
+  the import process has completed. "true" means that we should leave it in
+  the Space, "false" means to clean it out. Defaults to `false`.
+
+- `image_tags` ([]string) - A list of tags to apply to the resulting imported image.
+
+- `image_description` (string) - The description to set for the resulting imported image.
+
+- `image_distribution` (string) - The name of the distribution to set for the resulting imported image.
+
+- `timeout` (duration string | ex: "1h5m2s") - The length of time in minutes to wait for individual steps in the process
+  to successfully complete. This includes both importing the image from Spaces
+  as well as distributing the resulting image to additional regions. If not
+  specified, this will default to 20.
+
+<!-- End of code generated from the comments of the Config struct in post-processor/digitalocean-import/post-processor.go; -->

--- a/docs-partials/post-processor/digitalocean-import/Config-required.mdx
+++ b/docs-partials/post-processor/digitalocean-import/Config-required.mdx
@@ -1,0 +1,23 @@
+<!-- Code generated from the comments of the Config struct in post-processor/digitalocean-import/post-processor.go; DO NOT EDIT MANUALLY -->
+
+- `api_token` (string) - A personal access token used to communicate with the DigitalOcean v2 API.
+  This may also be set using the `DIGITALOCEAN_TOKEN` or
+  `DIGITALOCEAN_ACCESS_TOKEN` environmental variables.
+
+- `spaces_key` (string) - The access key used to communicate with Spaces. This may also be set using
+  the `DIGITALOCEAN_SPACES_ACCESS_KEY` environmental variable.
+
+- `spaces_secret` (string) - The secret key used to communicate with Spaces. This may also be set using
+  the `DIGITALOCEAN_SPACES_SECRET_KEY` environmental variable.
+
+- `spaces_region` (string) - The name of the region, such as `nyc3`, in which to upload the image to Spaces.
+
+- `space_name` (string) - The name of the specific Space where the image file will be copied to for
+  import. This Space must exist when the post-processor is run.
+
+- `image_name` (string) - The name to be used for the resulting DigitalOcean custom image.
+
+- `image_regions` ([]string) - A list of DigitalOcean regions, such as `nyc3`, where the resulting image
+  will be available for use in creating Droplets.
+
+<!-- End of code generated from the comments of the Config struct in post-processor/digitalocean-import/post-processor.go; -->

--- a/docs/post-processors/digitalocean-import.mdx
+++ b/docs/post-processors/digitalocean-import.mdx
@@ -50,62 +50,14 @@ There are some configuration options available for the post-processor.
 
 Required:
 
-- `api_token` (string) - A personal access token used to communicate with
-  the DigitalOcean v2 API. This may also be set using the
-  `DIGITALOCEAN_TOKEN` or `DIGITALOCEAN_ACCESS_TOKEN` environmental variables.
-  `DIGITALOCEAN_API_TOKEN` is acceptable but will be deprecated in a future release.
-
-- `spaces_key` (string) - The access key used to communicate with Spaces.
-  This may also be set using the `DIGITALOCEAN_SPACES_ACCESS_KEY`
-  environmental variable.
-
-- `spaces_secret` (string) - The secret key used to communicate with Spaces.
-  This may also be set using the `DIGITALOCEAN_SPACES_SECRET_KEY`
-  environmental variable.
-
-- `spaces_region` (string) - The name of the region, such as `nyc3`, in which
-  to upload the image to Spaces.
-
-- `space_name` (string) - The name of the specific Space where the image file
-  will be copied to for import. This Space must exist when the
-  post-processor is run.
-
-- `image_name` (string) - The name to be used for the resulting DigitalOcean
-  custom image.
-
-- `image_regions` (array of string) - A list of DigitalOcean regions, such
-  as `nyc3`, where the resulting image will be available for use in creating
-  Droplets.
+@include 'post-processor/digitalocean-import/Config-required.mdx'
 
 Optional:
 
-- `image_description` (string) - The description to set for the resulting
-  imported image.
-
-- `image_distribution` (string) - The name of the distribution to set for
-  the resulting imported image.
-
-- `image_tags` (array of strings) - A list of tags to apply to the resulting
-  imported image.
+@include 'post-processor/digitalocean-import/Config-required.mdx'
 
 - `keep_input_artifact` (boolean) - if true, do not delete the source virtual
   machine image after importing it to the cloud. Defaults to false.
-
-- `skip_clean` (boolean) - Whether we should skip removing the image file
-  uploaded to Spaces after the import process has completed. "true" means
-  that we should leave it in the Space, "false" means to clean it out.
-  Defaults to `false`.
-
-- `space_object_name` (string) - The name of the key used in the Space where
-  the image file will be copied to for import. This is treated as a
-  [template engine](/docs/templates/legacy_json_templates/engine). Therefore, you
-  may use user variables and template functions in this field.
-  If not specified, this will default to `packer-import-{{timestamp}}`.
-
-- `timeout` (number) - The length of time in minutes to wait for individual
-  steps in the process to successfully complete. This includes both importing
-  the image from Spaces as well as distributing the resulting image to
-  additional regions. If not specified, this will default to 20.
 
 ## Basic Example
 

--- a/post-processor/digitalocean-import/post-processor.go
+++ b/post-processor/digitalocean-import/post-processor.go
@@ -1,3 +1,4 @@
+//go:generate packer-sdc struct-markdown
 //go:generate packer-sdc mapstructure-to-hcl2 -type Config
 
 package digitaloceanimport
@@ -35,9 +36,16 @@ const BuilderId = "packer.post-processor.digitalocean-import"
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
-	APIToken     string `mapstructure:"api_token"`
-	SpacesKey    string `mapstructure:"spaces_key"`
-	SpacesSecret string `mapstructure:"spaces_secret"`
+	// A personal access token used to communicate with the DigitalOcean v2 API.
+	// This may also be set using the `DIGITALOCEAN_TOKEN` or
+	// `DIGITALOCEAN_ACCESS_TOKEN` environmental variables.
+	APIToken string `mapstructure:"api_token" required:"true"`
+	// The access key used to communicate with Spaces. This may also be set using
+	// the `DIGITALOCEAN_SPACES_ACCESS_KEY` environmental variable.
+	SpacesKey string `mapstructure:"spaces_key" required:"true"`
+	// The secret key used to communicate with Spaces. This may also be set using
+	// the `DIGITALOCEAN_SPACES_SECRET_KEY` environmental variable.
+	SpacesSecret string `mapstructure:"spaces_secret" required:"true"`
 	// The maximum number of retries for requests that fail with a 429 or 500-level error.
 	// The default value is 5. Set to 0 to disable reties.
 	HTTPRetryMax *int `mapstructure:"http_retry_max" required:"false"`
@@ -45,17 +53,35 @@ type Config struct {
 	HTTPRetryWaitMax *float64 `mapstructure:"http_retry_wait_max" required:"false"`
 	// The minimum wait time (in seconds) between failed API requests. Default: 1.0
 	HTTPRetryWaitMin *float64 `mapstructure:"http_retry_wait_min" required:"false"`
-
-	SpacesRegion string   `mapstructure:"spaces_region"`
-	SpaceName    string   `mapstructure:"space_name"`
-	ObjectName   string   `mapstructure:"space_object_name"`
-	SkipClean    bool     `mapstructure:"skip_clean"`
-	Tags         []string `mapstructure:"image_tags"`
-	Name         string   `mapstructure:"image_name"`
-	Description  string   `mapstructure:"image_description"`
-	Distribution string   `mapstructure:"image_distribution"`
-	ImageRegions []string `mapstructure:"image_regions"`
-
+	// The name of the region, such as `nyc3`, in which to upload the image to Spaces.
+	SpacesRegion string `mapstructure:"spaces_region" required:"true"`
+	// The name of the specific Space where the image file will be copied to for
+	// import. This Space must exist when the post-processor is run.
+	SpaceName string `mapstructure:"space_name" required:"true"`
+	// The name of the key used in the Space where the image file will be copied
+	// to for import. This is treated as a [template engine](/docs/templates/legacy_json_templates/engine).
+	// Therefore, you may use user variables and template functions in this field.
+	// If not specified, this will default to `packer-import-{{timestamp}}`.
+	ObjectName string `mapstructure:"space_object_name"`
+	// Whether we should skip removing the image file uploaded to Spaces after
+	// the import process has completed. "true" means that we should leave it in
+	// the Space, "false" means to clean it out. Defaults to `false`.
+	SkipClean bool `mapstructure:"skip_clean"`
+	// A list of tags to apply to the resulting imported image.
+	Tags []string `mapstructure:"image_tags"`
+	// The name to be used for the resulting DigitalOcean custom image.
+	Name string `mapstructure:"image_name" required:"true"`
+	// The description to set for the resulting imported image.
+	Description string `mapstructure:"image_description"`
+	// The name of the distribution to set for the resulting imported image.
+	Distribution string `mapstructure:"image_distribution"`
+	// A list of DigitalOcean regions, such as `nyc3`, where the resulting image
+	// will be available for use in creating Droplets.
+	ImageRegions []string `mapstructure:"image_regions" required:"true"`
+	// The length of time in minutes to wait for individual steps in the process
+	// to successfully complete. This includes both importing the image from Spaces
+	// as well as distributing the resulting image to additional regions. If not
+	// specified, this will default to 20.
 	Timeout time.Duration `mapstructure:"timeout"`
 
 	ctx interpolate.Context

--- a/post-processor/digitalocean-import/post-processor.hcl2spec.go
+++ b/post-processor/digitalocean-import/post-processor.hcl2spec.go
@@ -18,21 +18,21 @@ type FlatConfig struct {
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
-	APIToken            *string           `mapstructure:"api_token" cty:"api_token" hcl:"api_token"`
-	SpacesKey           *string           `mapstructure:"spaces_key" cty:"spaces_key" hcl:"spaces_key"`
-	SpacesSecret        *string           `mapstructure:"spaces_secret" cty:"spaces_secret" hcl:"spaces_secret"`
+	APIToken            *string           `mapstructure:"api_token" required:"true" cty:"api_token" hcl:"api_token"`
+	SpacesKey           *string           `mapstructure:"spaces_key" required:"true" cty:"spaces_key" hcl:"spaces_key"`
+	SpacesSecret        *string           `mapstructure:"spaces_secret" required:"true" cty:"spaces_secret" hcl:"spaces_secret"`
 	HTTPRetryMax        *int              `mapstructure:"http_retry_max" required:"false" cty:"http_retry_max" hcl:"http_retry_max"`
 	HTTPRetryWaitMax    *float64          `mapstructure:"http_retry_wait_max" required:"false" cty:"http_retry_wait_max" hcl:"http_retry_wait_max"`
 	HTTPRetryWaitMin    *float64          `mapstructure:"http_retry_wait_min" required:"false" cty:"http_retry_wait_min" hcl:"http_retry_wait_min"`
-	SpacesRegion        *string           `mapstructure:"spaces_region" cty:"spaces_region" hcl:"spaces_region"`
-	SpaceName           *string           `mapstructure:"space_name" cty:"space_name" hcl:"space_name"`
+	SpacesRegion        *string           `mapstructure:"spaces_region" required:"true" cty:"spaces_region" hcl:"spaces_region"`
+	SpaceName           *string           `mapstructure:"space_name" required:"true" cty:"space_name" hcl:"space_name"`
 	ObjectName          *string           `mapstructure:"space_object_name" cty:"space_object_name" hcl:"space_object_name"`
 	SkipClean           *bool             `mapstructure:"skip_clean" cty:"skip_clean" hcl:"skip_clean"`
 	Tags                []string          `mapstructure:"image_tags" cty:"image_tags" hcl:"image_tags"`
-	Name                *string           `mapstructure:"image_name" cty:"image_name" hcl:"image_name"`
+	Name                *string           `mapstructure:"image_name" required:"true" cty:"image_name" hcl:"image_name"`
 	Description         *string           `mapstructure:"image_description" cty:"image_description" hcl:"image_description"`
 	Distribution        *string           `mapstructure:"image_distribution" cty:"image_distribution" hcl:"image_distribution"`
-	ImageRegions        []string          `mapstructure:"image_regions" cty:"image_regions" hcl:"image_regions"`
+	ImageRegions        []string          `mapstructure:"image_regions" required:"true" cty:"image_regions" hcl:"image_regions"`
 	Timeout             *string           `mapstructure:"timeout" cty:"timeout" hcl:"timeout"`
 }
 

--- a/post-processor/digitalocean-import/post-processor.hcl2spec.go
+++ b/post-processor/digitalocean-import/post-processor.hcl2spec.go
@@ -21,6 +21,9 @@ type FlatConfig struct {
 	APIToken            *string           `mapstructure:"api_token" cty:"api_token" hcl:"api_token"`
 	SpacesKey           *string           `mapstructure:"spaces_key" cty:"spaces_key" hcl:"spaces_key"`
 	SpacesSecret        *string           `mapstructure:"spaces_secret" cty:"spaces_secret" hcl:"spaces_secret"`
+	HTTPRetryMax        *int              `mapstructure:"http_retry_max" required:"false" cty:"http_retry_max" hcl:"http_retry_max"`
+	HTTPRetryWaitMax    *float64          `mapstructure:"http_retry_wait_max" required:"false" cty:"http_retry_wait_max" hcl:"http_retry_wait_max"`
+	HTTPRetryWaitMin    *float64          `mapstructure:"http_retry_wait_min" required:"false" cty:"http_retry_wait_min" hcl:"http_retry_wait_min"`
 	SpacesRegion        *string           `mapstructure:"spaces_region" cty:"spaces_region" hcl:"spaces_region"`
 	SpaceName           *string           `mapstructure:"space_name" cty:"space_name" hcl:"space_name"`
 	ObjectName          *string           `mapstructure:"space_object_name" cty:"space_object_name" hcl:"space_object_name"`
@@ -56,6 +59,9 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"api_token":                  &hcldec.AttrSpec{Name: "api_token", Type: cty.String, Required: false},
 		"spaces_key":                 &hcldec.AttrSpec{Name: "spaces_key", Type: cty.String, Required: false},
 		"spaces_secret":              &hcldec.AttrSpec{Name: "spaces_secret", Type: cty.String, Required: false},
+		"http_retry_max":             &hcldec.AttrSpec{Name: "http_retry_max", Type: cty.Number, Required: false},
+		"http_retry_wait_max":        &hcldec.AttrSpec{Name: "http_retry_wait_max", Type: cty.Number, Required: false},
+		"http_retry_wait_min":        &hcldec.AttrSpec{Name: "http_retry_wait_min", Type: cty.Number, Required: false},
 		"spaces_region":              &hcldec.AttrSpec{Name: "spaces_region", Type: cty.String, Required: false},
 		"space_name":                 &hcldec.AttrSpec{Name: "space_name", Type: cty.String, Required: false},
 		"space_object_name":          &hcldec.AttrSpec{Name: "space_object_name", Type: cty.String, Required: false},


### PR DESCRIPTION
This enables retries for godo through out. 

Additionally, it changes post-processor docs to be generated from the code the same way as the builder and data source. 