### PR TITLE
Use correct go version in release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20
+          go-version: "1.21.x"
       - name: Describe plugin
         id: plugin_describe
         run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"


### PR DESCRIPTION
The release workflow failed. It's not entirely clear to me why, but I do see that it is installing an ancient version of go.

```yaml
      - name: Set up Go
        uses: actions/setup-go@v2
        with:
          go-version: 1.20
```

As the version is unquoted, yaml is interpreting it as `1.2`

https://github.com/digitalocean/packer-plugin-digitalocean/actions/runs/5956156841/job/16156328541#step:4:13