### PR TITLE
Remove CODEOWNERS file.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @andrewsomething 


### PR DESCRIPTION
This removes the `CODEOWNERS` file. The repo is set up to require approvals before merge and is maintained by the @digitalocean/api-cli team. I shouldn't personally need to review every PR. This is a hold over from when it was part of the HashiCorp org.