### PR TITLE
Update OS and size in examples.

### DIFF
--- a/.web-docs/components/builder/digitalocean/README.md
+++ b/.web-docs/components/builder/digitalocean/README.md
@@ -127,9 +127,9 @@ access tokens:
 ```hcl
 source "digitalocean" "example" {
   api_token    = "YOUR API KEY"
-  image        = "ubuntu-16-04-x64"
+  image        = "ubuntu-22-04-x64"
   region       = "nyc3"
-  size         = "512mb"
+  size         = "s-1vcpu-1gb"
   ssh_username = "root"
 }
 
@@ -144,9 +144,9 @@ build {
 {
   "type": "digitalocean",
   "api_token": "YOUR API KEY",
-  "image": "ubuntu-16-04-x64",
+  "image": "ubuntu-22-04-x64",
   "region": "nyc3",
-  "size": "512mb",
+  "size": "s-1vcpu-1gb",
   "ssh_username": "root"
 }
 ```

--- a/builder/digitalocean/builder_test.go
+++ b/builder/digitalocean/builder_test.go
@@ -10,7 +10,7 @@ func testConfig() map[string]interface{} {
 	return map[string]interface{}{
 		"api_token":    "bar",
 		"region":       "nyc2",
-		"size":         "512mb",
+		"size":         "s-1vcpu-1gb",
 		"ssh_username": "root",
 		"image":        "foo",
 	}

--- a/docs/builders/digitalocean.mdx
+++ b/docs/builders/digitalocean.mdx
@@ -51,9 +51,9 @@ access tokens:
 ```hcl
 source "digitalocean" "example" {
   api_token    = "YOUR API KEY"
-  image        = "ubuntu-16-04-x64"
+  image        = "ubuntu-22-04-x64"
   region       = "nyc3"
-  size         = "512mb"
+  size         = "s-1vcpu-1gb"
   ssh_username = "root"
 }
 
@@ -68,9 +68,9 @@ build {
 {
   "type": "digitalocean",
   "api_token": "YOUR API KEY",
-  "image": "ubuntu-16-04-x64",
+  "image": "ubuntu-22-04-x64",
   "region": "nyc3",
-  "size": "512mb",
+  "size": "s-1vcpu-1gb",
   "ssh_username": "root"
 }
 ```

--- a/example/basic_digitalocean.pkr.hcl
+++ b/example/basic_digitalocean.pkr.hcl
@@ -9,9 +9,9 @@ packer {
 
 source "digitalocean" "example" {
   api_token    = "YOUR API KEY"
-  image        = "ubuntu-16-04-x64"
+  image        = "ubuntu-22-04-x64"
   region       = "nyc3"
-  size         = "512mb"
+  size         = "s-1vcpu-1gb"
   ssh_username = "root"
 }
 

--- a/example/build.pkr.hcl
+++ b/example/build.pkr.hcl
@@ -9,9 +9,9 @@ packer {
 
 source "digitalocean" "example" {
   api_token    = "YOUR API KEY"
-  image        = "ubuntu-16-04-x64"
+  image        = "ubuntu-22-04-x64"
   region       = "nyc3"
-  size         = "512mb"
+  size         = "s-1vcpu-1gb"
   ssh_username = "root"
 }
 


### PR DESCRIPTION
Updates the OS and size used in examples to something more current. 

- `512mb` to `s-1vcpu-1gb` 
- `ubuntu-16-04-x64` to `ubuntu-22-04-x64`