### PR TITLE
Remove ci-release-docs step in goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,9 +6,7 @@ before:
   hooks:
     # We strongly recommend running tests to catch any regression before release.
     # Even though, this an optional step.
-    - go test ./... # As part of the release doc files are included as a separate deliverable for
-    # consumption by Packer.io. To include a separate docs.zip uncomment the following command.
-    - make ci-release-docs
+    - go test ./...
     # Check plugin compatibility with required version of the Packer SDK
     - make plugin-check
 builds:
@@ -72,13 +70,6 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
-release:
-  # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
-  # As part of the release doc files are included as a separate deliverable for consumption by Packer.io.
-  # To include a separate docs.zip uncomment the extra_files config and the docs.zip command hook above.
-  extra_files:
-  - glob: ./docs.zip
 
 changelog:
   use: github-native


### PR DESCRIPTION
Release failed due to changes from https://github.com/digitalocean/packer-plugin-digitalocean/pull/116. The `ci-release-docs` target was removed and is not longer needed. 

```
   • running                                        hook=make ci-release-docs
    • took: 20s
  ⨯ release failed after 20s                 error=hook failed: shell: 'make ci-release-docs': exit status 2: make: *** No rule to make target 'ci-release-docs'.  Stop.
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.24.0/x64/goreleaser' failed with exit code 1
```

https://github.com/digitalocean/packer-plugin-digitalocean/actions/runs/7891624778/job/21536335885#step:7:34