### PR TITLE
ci: Fix golangci linter failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.21.x, 1.22.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
@@ -40,10 +40,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
 
       - name: Lint with golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          only-new-issues: true
         if: matrix.os == 'ubuntu-latest'
+        run: make lint
 
       - name: Run unit tests
         run: make test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -43,7 +43,7 @@ check-generate: generate
 	fi
 
 install-golangci-lint:
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
 
 lint: install-golangci-lint
 	@golangci-lint run ./...


### PR DESCRIPTION
This fixes the linter failures we're seeing like https://github.com/digitalocean/packer-plugin-digitalocean/actions/runs/9116274911/job/25064521462?pr=142

Same as @danaelhe's changes in https://github.com/digitalocean/terraform-provider-digitalocean/pull/1156

