### PR TITLE
docs: match folder structure in metadata

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -32,8 +32,8 @@ $ packer plugins install github.com/digitalocean/digitalocean
 
 #### Data Sources
 
-- [digitalocean-image](/packer/integrations/digitalocean/digitalocean/latest/components/datasource/image) - The DigitalOcean image data source is used look up the ID of an existing DigitalOcean image for use as a builder source.
+- [digitalocean-image](/packer/integrations/digitalocean/digitalocean/latest/components/data-source/digitalocean-image) - The DigitalOcean image data source is used look up the ID of an existing DigitalOcean image for use as a builder source.
 
 #### Post-processors
 
-- [digitalocean-import](/packer/integrations/digitalocean/digitalocean/latest/components/post-processor/import) -processor](/docs/post-processors/digitalocean-import.mdx) - The digitalocean-import post-processor is used to import images to DigitalOcean
+- [digitalocean-import](/packer/integrations/digitalocean/digitalocean/latest/components/post-processor/digitalocean-import) - The digitalocean-import post-processor is used to import images to DigitalOcean

--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -7,7 +7,7 @@ integration {
   component {
     type = "data-source"
     name = "DigitalOcean Image"
-    slug = "image"
+    slug = "digitalocean-image"
   }
   component {
     type = "builder"
@@ -17,6 +17,6 @@ integration {
   component {
     type = "post-processor"
     name = "DigitalOcean Import"
-    slug = "import"
+    slug = "digitalocean-import"
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,8 @@ $ packer plugins install github.com/digitalocean/digitalocean
 
 #### Data Sources
 
-- [digitalocean-image](/packer/integrations/digitalocean/digitalocean/latest/components/datasource/image) - The DigitalOcean image data source is used look up the ID of an existing DigitalOcean image for use as a builder source.
+- [digitalocean-image](/packer/integrations/digitalocean/digitalocean/latest/components/data-source/digitalocean-image) - The DigitalOcean image data source is used look up the ID of an existing DigitalOcean image for use as a builder source.
 
 #### Post-processors
 
-- [digitalocean-import](/packer/integrations/digitalocean/digitalocean/latest/components/post-processor/import) -processor](/docs/post-processors/digitalocean-import.mdx) - The digitalocean-import post-processor is used to import images to DigitalOcean
+- [digitalocean-import](/packer/integrations/digitalocean/digitalocean/latest/components/post-processor/digitalocean-import) - The digitalocean-import post-processor is used to import images to DigitalOcean


### PR DESCRIPTION
This is an attempt at fixing https://github.com/digitalocean/packer-plugin-digitalocean/issues/147 The key change is updating the `slugs` in the metadata to match the folder structure (e.g. `digitalocean-image` instead of just `image`).

The HashiCorp side of this is a bit of a blackbox to me. So there might be some trial and error here.  