### PR TITLE
Prep v1.3.1 release.

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.3.0"
+	Version = "1.3.1"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
There are no functional changes in this release. Cutting it in the hopes that the docs change resolves #147

```
$ github-changelog-generator 
-org digitalocean -repo packer-plugin-digitalocean -token $GH_TOKEN
```
- #148 - @andrewsomething - docs: match folder structure in metadata
- #146 - @dependabot[bot] - Bump github.com/hashicorp/packer-plugin-sdk from 0.5.3 to 0.5.4
- #145 - @dependabot[bot] - Bump github.com/digitalocean/godo from 1.117.0 to 1.118.0
- #144 - @dependabot[bot] - Bump github.com/digitalocean/godo from 1.116.0 to 1.117.0
- #142 - @dependabot[bot] - Bump github.com/digitalocean/godo from 1.113.0 to 1.116.0
- #143 - @andrewsomething - ci: Fix golangci linter failure
- #138 - @dependabot[bot] - Bump github.com/digitalocean/godo from 1.110.0 to 1.113.0
- #139 - @dependabot[bot] - Bump github.com/hashicorp/packer-plugin-sdk from 0.5.2 to 0.5.3
- #135 - @lbajolet-hashicorp - makefile dev use packer install
- #134 - @dependabot[bot] - Bump github.com/digitalocean/godo from 1.109.0 to 1.110.0
