### PR TITLE
Update for goreleaser 2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,26 +24,32 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Unshallow
         run: git fetch --prune --unshallow
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: "1.21.x"
+
       - name: Describe plugin
         id: plugin_describe
         run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"
+
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --rm-dist
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,4 @@
-# This is an example goreleaser.yaml file with some defaults.
-# Make sure to check the documentation at http://goreleaser.com
+version: 2
 env:
   - CGO_ENABLED=0
 before:


### PR DESCRIPTION
Goreleaser 2.0 is out and the `--rm-dist` flag was replaced by `--clean`. 

https://goreleaser.com/blog/goreleaser-v2/#upgrading
