### PR TITLE
Issue #33 Add snapshot_tags

### DIFF
--- a/.web-docs/components/builder/digitalocean/README.md
+++ b/.web-docs/components/builder/digitalocean/README.md
@@ -106,6 +106,8 @@ each category, the available configuration keys are alphabetized.
 
 - `tags` ([]string) - Tags to apply to the droplet when it is created
 
+- `snapshot_tags` ([]string) - Tags to apply to the snapshot after it is created
+
 - `vpc_uuid` (string) - UUID of the VPC which the droplet will be created in. Before using this,
   private_networking should be enabled.
 

--- a/builder/digitalocean/builder_acc_test.go
+++ b/builder/digitalocean/builder_acc_test.go
@@ -166,7 +166,8 @@ const (
 		"region": "nyc2",
 		"size": "s-1vcpu-1gb",
 		"image": "%v",
-		"ssh_username": "root"
+		"ssh_username": "root",
+		"tags": ["tag1","tag2"]
 	}]
 }
 `
@@ -179,7 +180,8 @@ const (
 		"size": "s-1vcpu-1gb",
 		"image": "%v",
 		"ssh_username": "root",
-		"snapshot_regions": ["nyc1", "nyc2", "nyc3"]
+		"snapshot_regions": ["nyc1", "nyc2", "nyc3"],
+		"tags": ["tag1","tag2"]
 	}]
 }
 `
@@ -193,6 +195,7 @@ const (
 		"image": "%v",
 		"ssh_username": "root",
 		"snapshot_regions": ["nyc2", "nyc3"],
+		"tags": ["tag1","tag2"],
 		"wait_snapshot_transfer": false
 	}]
 }

--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -103,6 +103,8 @@ type Config struct {
 	UserDataFile string `mapstructure:"user_data_file" required:"false"`
 	// Tags to apply to the droplet when it is created
 	Tags []string `mapstructure:"tags" required:"false"`
+	// Tags to apply to the snapshot after it is created
+	SnapshotTags []string `mapstructure:"snapshot_tags" required:"false"`
 	// UUID of the VPC which the droplet will be created in. Before using this,
 	// private_networking should be enabled.
 	VPCUUID string `mapstructure:"vpc_uuid" required:"false"`

--- a/builder/digitalocean/config.hcl2spec.go
+++ b/builder/digitalocean/config.hcl2spec.go
@@ -89,6 +89,7 @@ type FlatConfig struct {
 	UserData                  *string           `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	UserDataFile              *string           `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	Tags                      []string          `mapstructure:"tags" required:"false" cty:"tags" hcl:"tags"`
+	SnapshotTags              []string          `mapstructure:"snapshot_tags" required:"false" cty:"snapshot_tags" hcl:"snapshot_tags"`
 	VPCUUID                   *string           `mapstructure:"vpc_uuid" required:"false" cty:"vpc_uuid" hcl:"vpc_uuid"`
 	ConnectWithPrivateIP      *bool             `mapstructure:"connect_with_private_ip" required:"false" cty:"connect_with_private_ip" hcl:"connect_with_private_ip"`
 	SSHKeyID                  *int              `mapstructure:"ssh_key_id" required:"false" cty:"ssh_key_id" hcl:"ssh_key_id"`
@@ -185,6 +186,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":               &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
 		"tags":                         &hcldec.AttrSpec{Name: "tags", Type: cty.List(cty.String), Required: false},
+		"snapshot_tags":                &hcldec.AttrSpec{Name: "snapshot_tags", Type: cty.List(cty.String), Required: false},
 		"vpc_uuid":                     &hcldec.AttrSpec{Name: "vpc_uuid", Type: cty.String, Required: false},
 		"connect_with_private_ip":      &hcldec.AttrSpec{Name: "connect_with_private_ip", Type: cty.Bool, Required: false},
 		"ssh_key_id":                   &hcldec.AttrSpec{Name: "ssh_key_id", Type: cty.Number, Required: false},

--- a/builder/digitalocean/step_snapshot.go
+++ b/builder/digitalocean/step_snapshot.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/digitalocean/godo"
@@ -77,6 +78,19 @@ func (s *stepSnapshot) Run(ctx context.Context, state multistep.StateBag) multis
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
+	}
+
+	if len(c.SnapshotTags) > 0 {
+		for _, tag := range c.SnapshotTags {
+			resp, err = client.Tags.TagResources(context.TODO(), tag, &godo.TagResourcesRequest{Resources: []godo.Resource{{ID: strconv.Itoa(imageId), Type: "image"}}})
+			if err != nil {
+				err := fmt.Errorf("Error Tagging Image: %s", err)
+				state.Put("error", err)
+				ui.Error(err.Error())
+				return multistep.ActionHalt
+			}
+			log.Printf("Added snapshot tag: %s", tag)
+		}
 	}
 
 	if len(c.SnapshotRegions) > 0 {

--- a/builder/digitalocean/step_snapshot.go
+++ b/builder/digitalocean/step_snapshot.go
@@ -82,14 +82,14 @@ func (s *stepSnapshot) Run(ctx context.Context, state multistep.StateBag) multis
 
 	if len(c.SnapshotTags) > 0 {
 		for _, tag := range c.SnapshotTags {
-			resp, err = client.Tags.TagResources(context.TODO(), tag, &godo.TagResourcesRequest{Resources: []godo.Resource{{ID: strconv.Itoa(imageId), Type: "image"}}})
+			_, err = client.Tags.TagResources(context.TODO(), tag, &godo.TagResourcesRequest{Resources: []godo.Resource{{ID: strconv.Itoa(imageId), Type: "image"}}})
 			if err != nil {
 				err := fmt.Errorf("Error Tagging Image: %s", err)
 				state.Put("error", err)
 				ui.Error(err.Error())
 				return multistep.ActionHalt
 			}
-			log.Printf("Added snapshot tag: %s", tag)
+			ui.Say(fmt.Sprintf("Added snapshot tag: %s...", tag))
 		}
 	}
 

--- a/docs-partials/builder/digitalocean/Config-not-required.mdx
+++ b/docs-partials/builder/digitalocean/Config-not-required.mdx
@@ -32,8 +32,6 @@
 
 - `snapshot_regions` ([]string) - Additional regions that resulting snapshot should be distributed to.
 
-- `snapshot_tags` ([]string) - Tags to apply to the resulting snapshot.
-
 - `wait_snapshot_transfer` (\*bool) - When true, Packer will block until all snapshot transfers have been completed
   and report errors. When false, Packer will initiate the snapshot transfers
   and exit successfully without waiting for completion. Defaults to true.
@@ -61,6 +59,8 @@
   data when launching the Droplet.
 
 - `tags` ([]string) - Tags to apply to the droplet when it is created
+
+- `snapshot_tags` ([]string) - Tags to apply to the snapshot after it is created
 
 - `vpc_uuid` (string) - UUID of the VPC which the droplet will be created in. Before using this,
   private_networking should be enabled.

--- a/docs-partials/builder/digitalocean/Config-not-required.mdx
+++ b/docs-partials/builder/digitalocean/Config-not-required.mdx
@@ -32,6 +32,8 @@
 
 - `snapshot_regions` ([]string) - Additional regions that resulting snapshot should be distributed to.
 
+- `snapshot_tags` ([]string) - Tags to apply to the resulting snapshot.
+
 - `wait_snapshot_transfer` (\*bool) - When true, Packer will block until all snapshot transfers have been completed
   and report errors. When false, Packer will initiate the snapshot transfers
   and exit successfully without waiting for completion. Defaults to true.


### PR DESCRIPTION
Adds a field, *snapshot_tags* to the builder that allows the user to specify a list of string tags that will be applied to the snapshot after creation. The core of this fix was proposed by @andiempettJISC in #33 and is a useful feature to developers that rely on tags to filter their images. 

Similar functionality exists in other builders, see: 
https://developer.hashicorp.com/packer/integrations/hashicorp/oracle/latest/components/builder/oci
https://developer.hashicorp.com/packer/integrations/hashicorp/amazon/latest/components/builder/ebs

Closes #33 . Acceptance tests and documentation included.

End-to-end test of building an image with the new *snapshot_tags* parameter, and a DigitalOcean API response showing them applied as intended:

![image](https://github.com/user-attachments/assets/cae12034-633a-4e08-b06c-4d74739fb3e3)

