### PR TITLE
builder: create tag if it does not exist.

### DIFF
--- a/builder/digitalocean/builder_acc_test.go
+++ b/builder/digitalocean/builder_acc_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/packer-plugin-digitalocean/version"
+	"github.com/google/uuid"
 	"github.com/hashicorp/packer-plugin-sdk/acctest"
 	"github.com/hashicorp/packer-plugin-sdk/useragent"
 	"golang.org/x/oauth2"
@@ -22,7 +23,7 @@ func TestBuilderAcc_basic(t *testing.T) {
 	}
 	acctest.TestPlugin(t, &acctest.PluginTestCase{
 		Name:     "test-digitalocean-builder-basic",
-		Template: fmt.Sprintf(testBuilderAccBasic, "ubuntu-20-04-x64"),
+		Template: fmt.Sprintf(testBuilderAccBasic, "ubuntu-20-04-x64", uuid.New().String()),
 		Check: func(buildCommand *exec.Cmd, logfile string) error {
 			if buildCommand.ProcessState != nil {
 				if buildCommand.ProcessState.ExitCode() != 0 {
@@ -152,7 +153,7 @@ func makeTemplateWithImageId(t *testing.T) string {
 			t.Fatalf("failed to retrieve image ID: %s", err)
 		}
 
-		return fmt.Sprintf(testBuilderAccBasic, image.ID)
+		return fmt.Sprintf(testBuilderAccBasic, image.ID, uuid.New().String())
 	}
 
 	return ""
@@ -167,7 +168,8 @@ const (
 		"size": "s-1vcpu-1gb",
 		"image": "%v",
 		"ssh_username": "root",
-		"tags": ["tag1","tag2"]
+		"tags": ["tag1","tag2"],
+		"snapshot_tags": ["%s"]
 	}]
 }
 `

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.4
 require (
 	github.com/aws/aws-sdk-go v1.44.114
 	github.com/digitalocean/godo v1.122.0
+	github.com/google/uuid v1.4.0
 	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/hashicorp/packer-plugin-sdk v0.5.4
 	github.com/mitchellh/mapstructure v1.5.0
@@ -39,7 +40,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
-	github.com/google/uuid v1.4.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	github.com/hashicorp/consul/api v1.25.1 // indirect


### PR DESCRIPTION
If the tag does not already exist when calling `TagResources`, we currently error out with a 404. It's a better user experience if we handle the error by creating the tag and trying again.